### PR TITLE
Fix callbacks for ox_lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # vxp_oilwell
+
+Sistema de pozos petroleros compatible con QBCore (o QBox), ox_lib, ox_inventory y oxmysql.
+
+El cliente y el servidor detectan automáticamente si se está utilizando `qb-core` o `qbx-core`.
+
+## Instalación
+
+1. Importe `schema.sql` en su base de datos.
+2. Coloque el recurso en la carpeta `resources` de su servidor.
+3. Asegúrese de tener `ox_lib`, `ox_inventory`, `oxmysql`, `ox_target` y `qb-core` o `qbx-core` instalados.
+4. Inicie el recurso desde `server.cfg`.

--- a/client.lua
+++ b/client.lua
@@ -1,5 +1,8 @@
+local coreName = GetResourceState("qbx-core") ~= "missing" and "qbx-core" or "qb-core"
+local QBCore = exports[coreName]:GetCoreObject()
+
 RegisterNetEvent('oil:showStatusMenu', function(well)
-    local playerCid = LocalPlayer.state.citizenid
+    local playerCid = QBCore.Functions.GetPlayerData().citizenid
     local ownerLabel = not well.owner and 'Disponible' or (well.owner == playerCid and 'Tú' or 'Otro Jugador')
 
     lib.registerContext({
@@ -15,11 +18,13 @@ RegisterNetEvent('oil:showStatusMenu', function(well)
 end)
 
 CreateThread(function()
-    while not LocalPlayer.state.citizenid do Wait(500) end
-    local cid = LocalPlayer.state.citizenid
+    while not QBCore.Functions.GetPlayerData().citizenid do
+        Wait(500)
+    end
+    local cid = QBCore.Functions.GetPlayerData().citizenid
 
     for _, loc in pairs(Config.OilLocations) do
-        lib.callback('oil:getWellOwner', false, loc.id, function(owner)
+        lib.callback('oil:getWellOwner', false, function(owner)
             local options = {
                 {
                     name = 'status_' .. loc.id,
@@ -66,6 +71,6 @@ CreateThread(function()
                 debug = false,
                 options = options
             })
-        end)
+        end, loc.id)
     end
 end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -17,8 +17,9 @@ server_scripts {
 }
 
 dependencies {
-    'qb-core',
     'ox_lib',
     'ox_inventory',
-    'oxmysql'
+    'oxmysql',
+    'ox_target'
 }
+-- qb-core or qbx-core should be installed but is detected at runtime

--- a/server.lua
+++ b/server.lua
@@ -1,4 +1,5 @@
-local QBCore = exports['qb-core']:GetCoreObject()
+local coreName = GetResourceState("qbx-core") ~= "missing" and "qbx-core" or "qb-core"
+local QBCore = exports[coreName]:GetCoreObject()
 local oilWells = {}
 
 AddEventHandler('onResourceStart', function(resource)
@@ -98,7 +99,7 @@ RegisterNetEvent('oil:maintain', function(wellId)
     TriggerClientEvent('ox_lib:notify', src, { description = 'Pozo mantenido correctamente.', type = 'success' })
 end)
 
-lib.callback.register('oil:getWellOwner', function(wellId)
+lib.callback.register('oil:getWellOwner', function(source, wellId)
     local well = oilWells[wellId]
     return well and well.owner or nil
 end)


### PR DESCRIPTION
## Summary
- fix ox_lib callback usage in client and server
- include ox_target dependency
- document setup instructions
- clarify README for QBox users
- detect qbx-core at runtime for broader compatibility
- remove hard qb-core dependency, autodetect core in client

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68816a25a650832998b9777ae59e7ca1